### PR TITLE
Add special retry strategy for GetPolicy to avoid throttling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "aws-types",
+ "backoff",
  "cedar-local-agent",
  "cedar-policy",
  "cedar-policy-core",
@@ -479,6 +480,20 @@ dependencies = [
  "http",
  "rustc_version",
  "tracing",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
 ]
 
 [[package]]
@@ -1279,6 +1294,15 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
  "serde",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ publish = false
 [dependencies]
 # Utilities
 async-trait = "0.1.71"
+backoff = { version = "0.4.0" , features = ["tokio"] }
 chrono = "0.4.26"
 derive_builder = "0.12.0"
 futures = { version = "0.3.28", features = ["std"] }
+http = "0.2.9"
 once_cell = "1.18.0"
 serde = { version = "1.0.166", features = ["derive"] }
 serde_json = "1.0.100"

--- a/src/private/sources/mod.rs
+++ b/src/private/sources/mod.rs
@@ -3,8 +3,16 @@ use async_trait::async_trait;
 
 pub mod cache;
 pub mod policy;
+mod retry;
 pub mod schema;
 pub mod template;
+
+/*
+    Retry AVP API calls for a max of 5 seconds
+    There is some randomness in the exponential backoff algorithm but this will likely result in
+    a maximum of 4-6 retries in the worst case
+*/
+pub static API_RETRY_TIMEOUT_IN_SECONDS: u64 = 5;
 
 /// Type values for cache changes
 #[derive(Debug, Eq, PartialEq)]

--- a/src/private/sources/retry.rs
+++ b/src/private/sources/retry.rs
@@ -1,0 +1,33 @@
+use crate::private::sources::API_RETRY_TIMEOUT_IN_SECONDS;
+use backoff::ExponentialBackoff;
+use std::time::Duration;
+
+/**
+The purpose of the `BackoffStrategy` is to allow fine grained control of
+the Backoff strategy rather than setting a single strategy at the level of the
+AVP client.
+
+The reason for this is that there are certain cases where we may need to retry several times
+with a long backoff since AVP has very low TPS limits and we expect to be throttled for certain
+operations. We do not want to allow these high numbers of retries universally
+ */
+pub struct BackoffStrategy {
+    pub(crate) time_limit_seconds: u64,
+}
+
+impl BackoffStrategy {
+    pub(crate) fn get_backoff(&self) -> ExponentialBackoff {
+        let mut exponential_backoff = ExponentialBackoff::default();
+        exponential_backoff.max_elapsed_time =
+            Option::from(Duration::from_secs(self.time_limit_seconds));
+        exponential_backoff
+    }
+}
+
+impl Default for BackoffStrategy {
+    fn default() -> Self {
+        Self {
+            time_limit_seconds: API_RETRY_TIMEOUT_IN_SECONDS,
+        }
+    }
+}


### PR DESCRIPTION
Add special retry strategy for GetPolicy requests since these requests are likely to get throttled and should be given a longer backoff.

*Issue #, if available:* https://github.com/awslabs/avp-local-agent/issues/8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
