### PR TITLE
Create initial OSS doc files: PR/Issues templates, contributing, etc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,113 @@
+name: Bug report
+description: Create a report to help us improve AVP Local Agent
+labels: [ pending-triage, bug ]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Try to include as much information as you can.
+
+  - type: checkboxes
+    attributes:
+      label: |
+        Before opening, please confirm:
+      options:
+        - label: I have [searched for duplicate or closed issues](https://github.com/awslabs/avp-local-agent/issues?q=is%3Aissue+).
+          required: true
+        - label: I have read the guide for [submitting bug reports](https://github.com/awslabs/avp-local-agent/blob/main/CONTRIBUTING.md#reporting-bugsfeature-requests).
+          required: true
+        - label: I have done my best to include a minimal, self-contained set of instructions for consistently reproducing the issue.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Category
+  - type: dropdown
+    attributes:
+      label: Bug Category
+      description: What part of AVP Local Agent is this bug related to?
+      multiple: true
+      options:
+        - Entity provider
+        - PolicySet provider
+        - AVP integration
+        - Logging
+        - Other
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Details
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Reproduction steps
+      description: |
+        How do you trigger this bug? Please walk us through it step by step. Screenshots can be attached in textarea below.
+      placeholder: |
+        1. Install '...'
+        2. Configure '...'
+        3. Go to '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Code Snippet
+      description: |
+        Please provide a code snippet or a link to sample code of the issue you are experiencing to help us reproduce the issue. 
+        Please also include relevant Cedar policies, entity data, or client configuration, if applicable.
+
+        **Be sure to remove any sensitive data.**
+      value: |
+        ```rust
+        // Put your code below this line.
+
+        ```
+  - type: textarea
+    attributes:
+      label: Log output
+      description: |
+        For example, error messages, or stack traces.
+        **Be sure to remove any sensitive data.**
+      value: |
+        ```
+        // Put your output below this line
+
+        ```
+  - type: markdown
+    attributes:
+      value: |
+        ## Configuration
+  - type: textarea
+    attributes:
+      label: Additional configuration
+      description: |
+        If applicable, provide more configuration data.
+        **Be sure to remove any sensitive data**
+
+  - type: input
+    attributes:
+      label: Operating  System
+      description: e.g. Linux, MacOS (Intel), MacOS (ARM)
+  - type: textarea
+    attributes:
+      label: Additional information and screenshots
+      description: |
+        If you have any additional information, workarounds, etc. for us, use the field below.
+        Please note, you can attach screenshots or screen recordings here by
+        dragging and dropping files in the field below.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Suggest an idea for AVP Local Agent
+labels: [pending-triage, feature-request]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to submit a feature request! Try to include as much information as you can.
+
+  - type: dropdown
+    attributes:
+      label: Category
+      description: What component of AVP Local Agent does this feature relate to?
+      multiple: true
+      options:
+        - Entity provider
+        - PolicySet provider
+        - AVP integration
+        - Logging
+        - User level API changes
+        - Internal refactors/changes
+        - Documentation and code comments
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the feature you would like to request
+      description: |
+        A clear and concise description of what you want to happen. Please include **any related issues**, documentation, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: |
+        A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other use cases or context about the feature request here. Please include any prototype/sandbox, 
+        workaround, reference implementation, etc.
+
+  - type: checkboxes
+    attributes:
+      label: Is this something that you'd be interested in working on?
+      options:
+        - label: 👋 I may be able to implement this feature request
+        - label: ⚠️ This feature might incur a breaking change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description of changes
+
+## Issue #, if available
+
+## Checklist for requesting a review
+
+The change in this PR is (choose one, and delete the other options):
+
+- [ ] A breaking change requiring a major version bump to `avp-local-agent` (e.g., changes to the signature of an
+  existing API).
+- [ ] A backwards-compatible change requiring a minor version bump to `avp-local-agent` (e.g., addition of a new API).
+- [ ] A bug fix or other functionality change requiring a patch to `avp-local-agent`.
+- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)
+- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.
+
+I confirm that this PR (choose one, and delete the other options):
+
+- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor
+  version bumps).
+- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.
+
+## Testing
+
+Add a description on how the code changes were tested, if applicable.
+
+Hint: run `./scripts/build_and_test.sh` script to validate your changes locally before submitting a PR. It replicates
+our GitHub CI/CD validations as close as possible.
+
+## Disclaimer
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
+terms of your choice.

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -8,3 +8,4 @@ env:
 jobs:
   build_and_test:
     uses: ./.github/workflows/build_and_test.yml
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+## 1.0.0 - 2023-11-20
+Cedar Local Agent Version: 1.0.0
+- Initial release of `avp-local-agent`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or
+additional
 documentation, we greatly value feedback and contributions from our community.
 
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
-
 
 ## Reporting Bugs/Feature Requests
 
@@ -19,19 +19,22 @@ reported the issue. Please try to include as much information as you can. Detail
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
-
 ## Contributing via Pull Requests
+
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
 1. You are working against the latest source on the *main* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem
+   already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
 To send us a pull request, please:
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it
+   will be hard for us to focus on your change.
+3. Ensure local tests and validations pass. You can run `./scripts/build_and_test.sh` to validate your changes locally
+   before submitting a PR.
 4. Commit to your fork using clear commit messages.
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
@@ -39,21 +42,25 @@ To send us a pull request, please:
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the
+default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help
+wanted' issues is a great place to start.
 
 ## Code of Conduct
+
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
-
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via
+our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a
+public GitHub issue.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your
+contribution.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# SECURITY.md
+
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via
+our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email
+to [aws-security@amazon.com](mailto:aws-security@amazon.com). Please do not create a public GitHub issue.


### PR DESCRIPTION
*Issue #, if available:* #13

*Description of changes:* 
Adds templates for contributing, pull requests, issues, security discoveries.

These artifacts are based in the ones adopted in [Cedar Policy repository](https://github.com/cedar-policy/cedar).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
