### PR TITLE
Improved error messages of the AVP translator and removed unused errors

### DIFF
--- a/src/private/translator/error.rs
+++ b/src/private/translator/error.rs
@@ -1,5 +1,3 @@
-use cedar_policy::SchemaError;
-use cedar_policy_core::parser::err::ParseErrors;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -16,20 +14,12 @@ pub enum TranslatorException {
     EntityIdNotFound(),
     #[error("Input is invalid.")]
     InvalidInput(),
-    #[error("Error occurred when parsing the object: {0}.")]
-    ParseObject(#[source] ParseErrors),
-    #[error("Error occurred when parsing the schema: {0}")]
-    ParseSchema(#[source] SchemaError),
-}
-
-impl From<ParseErrors> for TranslatorException {
-    fn from(err: ParseErrors) -> Self {
-        Self::ParseObject(err)
-    }
-}
-
-impl From<SchemaError> for TranslatorException {
-    fn from(err: SchemaError) -> Self {
-        Self::ParseSchema(err)
-    }
+    #[error("Error occurred when parsing the policy, policy id: {0}.")]
+    ParsePolicy(String),
+    #[error("Error occurred when parsing the entity in the policy, policy id: {0}.")]
+    ParseEntity(String),
+    #[error("Error occurred when parsing the template, template id: {0}.")]
+    ParseTemplate(String),
+    #[error("Error occurred when parsing the schema")]
+    ParseSchema(),
 }

--- a/src/public/entity_provider.rs
+++ b/src/public/entity_provider.rs
@@ -37,9 +37,6 @@ pub enum ProviderError {
     /// Entities file is malformed in some way
     #[error("The Entities failed to be parsed: {0}")]
     EntitiesError(#[source] EntitiesError),
-    /// When the file system entity provider cannot update it's data
-    #[error("The update provider failed to update the entities: {0}")]
-    UpdateError(#[source] UpdateProviderDataError),
 }
 
 impl From<SchemaError> for ProviderError {

--- a/src/public/policy_set_provider.rs
+++ b/src/public/policy_set_provider.rs
@@ -39,9 +39,6 @@ pub enum ProviderError {
     /// Cannot retrieve the Templates from Amazon Verified Permissions
     #[error("Cannot gather the Policies from Amazon Verified Permissions: {0}")]
     TemplateSourceException(#[source] TemplateSourceException),
-    /// When the file system entity provider cannot update it's data
-    #[error("The update provider failed to update the entities: {0}")]
-    Update(#[source] UpdateProviderDataError),
 }
 
 impl From<TemplateSourceException> for ProviderError {


### PR DESCRIPTION
## Description of changes

Improved error messages of the AVP translator. Replaced underlying parsing errors with policy id or template id.

Also removed some unused errors.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)
I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing

Add a description on how the code changes were tested, if applicable.

Hint: run `./scripts/build_and_test.sh` script to validate your changes locally before submitting a PR. It replicates
our GitHub CI/CD validations as close as possible.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
