### PR TITLE
Improved error messages of policy set provider and entity provider

### DIFF
--- a/src/public/entity_provider.rs
+++ b/src/public/entity_provider.rs
@@ -30,25 +30,13 @@ pub enum ProviderError {
     Configuration(String),
     /// Cannot retrieve the schema from Amazon Verified Permissions
     #[error("Failed to get the schema from Amazon Verified Permissions: {0}")]
-    RetrieveException(#[source] SchemaException),
+    RetrieveException(#[from] SchemaException),
     /// Schema file is malformed in some way
     #[error("The Schema file failed to be parsed")]
-    SchemaParse(),
+    SchemaParse(#[from] SchemaError),
     /// Cannot extract entities from the schema
     #[error("Failed to extract entities from the schema")]
-    Entities(),
-}
-
-impl From<SchemaError> for ProviderError {
-    fn from(_value: SchemaError) -> Self {
-        Self::SchemaParse()
-    }
-}
-
-impl From<EntitiesError> for ProviderError {
-    fn from(_value: EntitiesError) -> Self {
-        Self::Entities()
-    }
+    ExtractEntities(#[from] EntitiesError),
 }
 
 impl From<ConfigBuilderError> for ProviderError {

--- a/src/public/policy_set_provider.rs
+++ b/src/public/policy_set_provider.rs
@@ -31,13 +31,13 @@ pub enum ProviderError {
     Configuration(String),
     /// Cannot create the policy set
     #[error("Cannot create the PolicySet with source Amazon Verified Permissions: {0}")]
-    PolicySet(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    PolicySet(#[from] PolicySetError),
     /// Cannot retrieve the Policies from Amazon Verified Permissions
     #[error("Cannot gather the Policies from Amazon Verified Permissions: {0}")]
-    PolicySourceException(#[source] PolicySourceException),
+    PolicySourceException(#[from] PolicySourceException),
     /// Cannot retrieve the Templates from Amazon Verified Permissions
     #[error("Cannot gather the Policies from Amazon Verified Permissions: {0}")]
-    TemplateSourceException(#[source] TemplateSourceException),
+    TemplateSourceException(#[from] TemplateSourceException),
 }
 
 /// The enum for errors that occur when building the `PolicySet`
@@ -52,24 +52,6 @@ pub enum PolicySetError {
     ///Cannot add the template to the policy set
     #[error("Fail to add the template to the policy set, template id: {0}")]
     Template(String),
-}
-
-impl From<TemplateSourceException> for ProviderError {
-    fn from(value: TemplateSourceException) -> Self {
-        Self::TemplateSourceException(value)
-    }
-}
-
-impl From<PolicySourceException> for ProviderError {
-    fn from(value: PolicySourceException) -> Self {
-        Self::PolicySourceException(value)
-    }
-}
-
-impl From<PolicySetError> for ProviderError {
-    fn from(value: PolicySetError) -> Self {
-        Self::PolicySet(Box::new(value))
-    }
 }
 
 impl From<ConfigBuilderError> for ProviderError {
@@ -167,7 +149,7 @@ impl PolicySetProvider {
         for (_, template) in templates {
             policy_set
                 .add_template(template.0.clone())
-                .map_err(|_e| PolicySetError::Template(template.0.id().to_string()))?;
+                .map_err(|_| PolicySetError::Template(template.0.id().to_string()))?;
         }
 
         for (_, policy) in policies {
@@ -176,18 +158,18 @@ impl PolicySetProvider {
                     let cedar_policy_id = &cedar_policy.id().clone();
                     policy_set
                         .add(cedar_policy)
-                        .map_err(|_e| PolicySetError::StaticPolicy(cedar_policy_id.to_string()))?;
+                        .map_err(|_| PolicySetError::StaticPolicy(cedar_policy_id.to_string()))?;
                 }
                 Policy::TemplateLinked(policy_id, template_id, entity_map) => {
                     let cedar_policy_id =
-                        PolicyId::from_str(&policy_id.to_string()).map_err(|_e| {
+                        PolicyId::from_str(&policy_id.to_string()).map_err(|_| {
                             PolicySetError::TemplateLinkedPolicy(
                                 policy_id.to_string(),
                                 template_id.to_string(),
                             )
                         })?;
                     let cedar_template_id =
-                        PolicyId::from_str(&template_id.to_string()).map_err(|_e| {
+                        PolicyId::from_str(&template_id.to_string()).map_err(|_| {
                             PolicySetError::TemplateLinkedPolicy(
                                 policy_id.to_string(),
                                 template_id.to_string(),
@@ -195,7 +177,7 @@ impl PolicySetProvider {
                         })?;
                     policy_set
                         .link(cedar_template_id, cedar_policy_id, entity_map)
-                        .map_err(|_e| {
+                        .map_err(|_| {
                             PolicySetError::TemplateLinkedPolicy(
                                 policy_id.to_string(),
                                 template_id.to_string(),
@@ -252,7 +234,7 @@ impl UpdateProviderData for PolicySetProvider {
         for (_, template) in templates {
             policy_set_data
                 .add_template(template.0.clone())
-                .map_err(|_e| {
+                .map_err(|_| {
                     UpdateProviderDataError::General(Box::new(ProviderError::from(
                         PolicySetError::Template(template.0.id().to_string()),
                     )))
@@ -263,7 +245,7 @@ impl UpdateProviderData for PolicySetProvider {
             match policy {
                 Policy::Static(cedar_policy) => {
                     let cedar_policy_id = &cedar_policy.id().clone();
-                    policy_set_data.add(cedar_policy).map_err(|_e| {
+                    policy_set_data.add(cedar_policy).map_err(|_| {
                         UpdateProviderDataError::General(Box::new(PolicySetError::StaticPolicy(
                             cedar_policy_id.to_string(),
                         )))
@@ -271,7 +253,7 @@ impl UpdateProviderData for PolicySetProvider {
                 }
                 Policy::TemplateLinked(policy_id, template_id, entity_map) => {
                     let cedar_policy_id =
-                        PolicyId::from_str(&policy_id.to_string()).map_err(|_e| {
+                        PolicyId::from_str(&policy_id.to_string()).map_err(|_| {
                             UpdateProviderDataError::General(Box::new(
                                 PolicySetError::TemplateLinkedPolicy(
                                     policy_id.to_string(),
@@ -280,7 +262,7 @@ impl UpdateProviderData for PolicySetProvider {
                             ))
                         })?;
                     let cedar_template_id =
-                        PolicyId::from_str(&template_id.to_string()).map_err(|_e| {
+                        PolicyId::from_str(&template_id.to_string()).map_err(|_| {
                             UpdateProviderDataError::General(Box::new(
                                 PolicySetError::TemplateLinkedPolicy(
                                     policy_id.to_string(),
@@ -290,7 +272,7 @@ impl UpdateProviderData for PolicySetProvider {
                         })?;
                     policy_set_data
                         .link(cedar_template_id, cedar_policy_id, entity_map)
-                        .map_err(|_e| {
+                        .map_err(|_| {
                             UpdateProviderDataError::General(Box::new(
                                 PolicySetError::TemplateLinkedPolicy(
                                     policy_id.to_string(),


### PR DESCRIPTION
## Description of changes

Improved error messages of avp agent policy set provider and entity provider.

Replaced underlying error messages with self defined errors to avoid sensitive data leaking. For the `UpdateProviderDataError`, the code still keep using `UpdateProviderDataError::General` type but replaced errors it wrapped.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing

Add a description on how the code changes were tested, if applicable.

Hint: run `./scripts/build_and_test.sh` script to validate your changes locally before submitting a PR. It replicates
our GitHub CI/CD validations as close as possible.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
