### PR TITLE
Update cedar version to 2.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ thiserror = "1.0.41"
 tracing = "0.1.37"
 
 # Cedar
-cedar-policy = "2.3.0"
-cedar-policy-core = "2.3.0"
-cedar-policy-formatter = "2.3.0"
-cedar-policy-validator = "2.3.0"
+cedar-policy = "2.4.2"
+cedar-policy-core = "2.4.2"
+cedar-policy-formatter = "2.4.2"
+cedar-policy-validator = "2.4.2"
 
 # AWS
 aws-config = "1.0.1"


### PR DESCRIPTION
## Description of changes
This PR updates cedar-policy dependencies from `2.3.0` to `2.4.2`

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing

`cargo test --features integration-tests`
```

test result: ok. 105 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.91s

     Running tests/lib.rs (target/debug/deps/lib-33c97b64bff09310)

running 2 tests
test test::simple_authorizer_with_valid_data ... ok
test test::simple_authorizer_with_many_policies ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 56.44s

   Doc-tests avp-local-agent

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
