### PR TITLE
Remove backoff, replace with backon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
- "backoff",
+ "backon",
  "cedar-local-agent",
  "cedar-policy",
  "chrono",
@@ -475,16 +475,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "970d91570c01a8a5959b36ad7dd1c30642df24b6b3068710066f6809f7033bb7"
 dependencies = [
- "futures-core",
- "getrandom",
- "instant",
- "pin-project-lite",
- "rand",
+ "fastrand",
+ "gloo-timers",
  "tokio",
 ]
 
@@ -1241,6 +1238,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,15 +1610,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
  "serde",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ tracing = "0.1.37"
 
 # Utilities
 async-trait = "0.1.71"
-backoff = { version = "0.4.0" , features = ["tokio"] }
+backon = { version = "1" }
+# backoff = { version = "0.4.0" , features = ["tokio"] }
 chrono = "0.4.26"
 derive_builder = "0.20.2"
 serde = { version = "1.0.166", features = ["derive"] }

--- a/src/private/sources/policy/reader.rs
+++ b/src/private/sources/policy/reader.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use aws_sdk_verifiedpermissions::operation::get_policy::{GetPolicyError, GetPolicyOutput};
 use aws_sdk_verifiedpermissions::Client;
 use aws_smithy_runtime_api::client::result::SdkError;
+use backon::Retryable;
 use tracing::instrument;
 
 use crate::private::sources::policy::error::PolicyException;
@@ -48,8 +49,9 @@ impl GetPolicy {
                 .map_err(SdkError::into_service_error)?;
             Ok(get_policy_result)
         };
-
-        backoff::future::retry(self.backoff_strategy.get_backoff(), get_policy_operation).await
+        get_policy_operation
+            .retry(self.backoff_strategy.get_backoff())
+            .await
     }
 }
 

--- a/src/private/sources/retry.rs
+++ b/src/private/sources/retry.rs
@@ -1,4 +1,4 @@
-use backoff::ExponentialBackoff;
+use backon::{BackoffBuilder, ExponentialBuilder};
 use std::time::Duration;
 
 /*
@@ -27,11 +27,10 @@ pub struct BackoffStrategy {
 }
 
 impl BackoffStrategy {
-    pub(crate) fn get_backoff(&self) -> ExponentialBackoff {
-        ExponentialBackoff {
-            max_elapsed_time: Option::from(Duration::from_secs(self.time_limit_seconds)),
-            ..Default::default()
-        }
+    pub(crate) fn get_backoff(&self) -> backon::ExponentialBackoff {
+        ExponentialBuilder::new()
+            .with_max_delay(Duration::from_secs(self.time_limit_seconds))
+            .build()
     }
 }
 

--- a/src/private/sources/schema/reader.rs
+++ b/src/private/sources/schema/reader.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use aws_sdk_verifiedpermissions::operation::get_schema::{GetSchemaError, GetSchemaOutput};
 use aws_sdk_verifiedpermissions::Client;
 use aws_smithy_runtime_api::client::result::SdkError;
+use backon::Retryable;
 use tracing::instrument;
 
 /// This structure implements the calls to Amazon Verified Permissions for retrieving the schema.
@@ -43,7 +44,9 @@ impl GetSchema {
             Ok(get_policy_result)
         };
 
-        backoff::future::retry(self.backoff_strategy.get_backoff(), get_policy_operation).await
+        get_policy_operation
+            .retry(self.backoff_strategy.get_backoff())
+            .await
     }
 }
 

--- a/src/private/sources/template/reader.rs
+++ b/src/private/sources/template/reader.rs
@@ -7,6 +7,7 @@ use aws_sdk_verifiedpermissions::operation::get_policy_template::{
 };
 use aws_sdk_verifiedpermissions::Client;
 use aws_smithy_runtime_api::client::result::SdkError;
+use backon::Retryable;
 use tracing::instrument;
 
 use crate::private::sources::retry::BackoffStrategy;
@@ -50,12 +51,9 @@ impl GetPolicyTemplate {
                 .map_err(SdkError::into_service_error)?;
             Ok(get_policy_result)
         };
-
-        backoff::future::retry(
-            self.backoff_strategy.get_backoff(),
-            get_policy_template_operation,
-        )
-        .await
+        get_policy_template_operation
+            .retry(self.backoff_strategy.get_backoff())
+            .await
     }
 }
 


### PR DESCRIPTION
## Description of changes
The `backoff` crate has been marked [unmaintained](https://rustsec.org/advisories/RUSTSEC-2025-0012). The `backon` crate is the recommended replacement.

The PR does just that.
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `avp-local-agent` (e.g., changes to the signature of an
  existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `avp-local-agent` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `avp-local-agent`.
- [ X] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor
  version bumps).
- [ X] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing

`./scripts/build_and_test.sh` was run - it runs to the end without error (and, of course, clears up the previous failure that informs us that `backoff` is unmaintained :))

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
